### PR TITLE
Use XDG_SESSION_TYPE and XDG_CURRENT_DESKTOP instead of DESKTOP_SESSION

### DIFF
--- a/lib/fusuma/plugin/appmatcher.rb
+++ b/lib/fusuma/plugin/appmatcher.rb
@@ -13,11 +13,30 @@ module Fusuma
 
       # @return [Class]
       def backend_klass
-        if ENV['DESKTOP_SESSION'] == 'ubuntu-wayland'
-          Gnome
-        else
-          X11
+        case xdg_session_type
+        when /x11/
+          return X11
+        when /wayland/
+          return Gnome if xdg_current_desktop =~ /GNOME/
         end
+        MultiLogger.error(
+          <<~ERROR
+          appmatcher doesn't support
+          XDG_CURRENT_DESKTOP: '#{xdg_current_desktop}'
+          XDG_SESSION_TYPE: '#{xdg_session_type}'"
+          ERROR
+        )
+        exit 1
+      end
+
+      private
+
+      def xdg_session_type
+        ENV.fetch('XDG_SESSION_TYPE', '')
+      end
+
+      def xdg_current_desktop
+        ENV.fetch('XDG_CURRENT_DESKTOP', '')
       end
     end
   end

--- a/spec/fusuma/plugin/appmatcher_spec.rb
+++ b/spec/fusuma/plugin/appmatcher_spec.rb
@@ -2,8 +2,38 @@
 
 require 'spec_helper'
 
-RSpec.describe Fusuma::Plugin::Appmatcher do
-  it 'has a version number' do
-    expect(Fusuma::Plugin::Appmatcher::VERSION).not_to be nil
+module Fusuma
+  module Plugin
+    RSpec.describe Appmatcher do
+      it 'has a version number' do
+        expect(Appmatcher::VERSION).not_to be nil
+      end
+
+      describe '#backend_klass' do
+        context 'when XDG_CURRENT_DESKTOP is UNKNOWN' do
+          before { allow(Appmatcher).to receive(:xdg_current_desktop).and_return('UNKNOWN') }
+          it { expect { Appmatcher.backend_klass }.to raise_error }
+        end
+
+        context 'when XDG_SESSION_TYPE is x11' do
+          before { allow(Appmatcher).to receive(:xdg_session_type).and_return('x11') }
+          it { expect(Appmatcher.backend_klass).to eq Appmatcher::X11 }
+        end
+
+        context 'when XDG_SESSION_TYPE is wayland' do
+          before { allow(Appmatcher).to receive(:xdg_session_type).and_return('wayland') }
+
+          context 'when XDG_CURRENT_DESKTOP is GNOME' do
+            before { allow(Appmatcher).to receive(:xdg_current_desktop).and_return('GNOME') }
+            it { expect(Appmatcher.backend_klass).to eq Appmatcher::Gnome }
+          end
+
+          context 'when XDG_CURRENT_DESKTOP is UNKNOWN' do
+            before { allow(Appmatcher).to receive(:xdg_current_desktop).and_return('UNKNOWN') }
+            it { expect { Appmatcher.backend_klass }.to raise_error }
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/fusuma/plugin/appmatcher_spec.rb
+++ b/spec/fusuma/plugin/appmatcher_spec.rb
@@ -23,8 +23,8 @@ module Fusuma
         context 'when XDG_SESSION_TYPE is wayland' do
           before { allow(Appmatcher).to receive(:xdg_session_type).and_return('wayland') }
 
-          context 'when XDG_CURRENT_DESKTOP is GNOME' do
-            before { allow(Appmatcher).to receive(:xdg_current_desktop).and_return('GNOME') }
+          context 'when XDG_CURRENT_DESKTOP is ubuntu:GNOME' do
+            before { allow(Appmatcher).to receive(:xdg_current_desktop).and_return('ubuntu:GNOME') }
             it { expect(Appmatcher.backend_klass).to eq Appmatcher::Gnome }
           end
 


### PR DESCRIPTION
fusuma-plugin-appmatcher should use XDG_SESSION_TYPE and XDG_CURRENT_DESKTOP instead of DESKTOP_SESSION for switching backend.


On Wayland Gnome on Ubuntu 21.10

```bash
iberianpig@ubuntu2110:~/dotfiles$ env | grep DESKTOP_SESSION
GNOME_DESKTOP_SESSION_ID=this-is-deprecated
DESKTOP_SESSION=ubuntu
```

As shown above, DESKTOP_SESSION can no longer detect whether you are using X11 or Wayland Gnome.

ref: https://github.com/iberianpig/fusuma-plugin-sendkey/issues/23#issuecomment-956256637