### PR TITLE
chore(Gemfile): add rspec-debug gem

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: 3.2
 
     - name: Publish to RubyGems
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.5'
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "pry-inline"
 gem "rake", "~> 13.0"
 gem "reek"
 gem "rspec", "~> 3.0"
+gem 'rspec-debug'
 gem "rubocop"
 gem "rubocop-rake"
 gem "rubocop-rspec"

--- a/fusuma-plugin-appmatcher.gemspec
+++ b/fusuma-plugin-appmatcher.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fusuma", ">= 3.0"
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.required_ruby_version = ">= 2.5.1" # https://packages.ubuntu.com/search?keywords=ruby&searchon=names&exact=1&suite=all&section=main
-  # support bionic (18.04LTS) 2.5.1
+  spec.required_ruby_version = ">= 2.7"
+  # https://packages.ubuntu.com/search?keywords=ruby&searchon=names&exact=1&suite=all&section=main
+  # support focal (20.04LTS) 2.7
 end

--- a/spec/fusuma/plugin/detectors/appmatcher_detector_spec.rb
+++ b/spec/fusuma/plugin/detectors/appmatcher_detector_spec.rb
@@ -30,7 +30,7 @@ module Fusuma
         context "with appmatcher events in buffer" do
           before do
             record = Events::Records::AppmatcherRecord.new(name: "dummy")
-            event = Events::Event.new(tag: "appmatcher_parser", record: record)
+            event = Events::Event.new(tag: "appmatcher_input", record: record)
 
             @buffer.buffer(event)
           end
@@ -49,8 +49,8 @@ module Fusuma
           before do
             record1 = Events::Records::AppmatcherRecord.new(name: "dummy1")
             record2 = Events::Records::AppmatcherRecord.new(name: "dummy2")
-            event1 = Events::Event.new(tag: "appmatcher_parser", record: record1)
-            event2 = Events::Event.new(tag: "appmatcher_parser", record: record2)
+            event1 = Events::Event.new(tag: "appmatcher_input", record: record1)
+            event2 = Events::Event.new(tag: "appmatcher_input", record: record2)
 
             @buffer.buffer(event1)
             @buffer.buffer(event2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "bundler/setup"
 require "fusuma/plugin/appmatcher"
+require 'rspec/debug'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
use https://github.com/ko1/rspec-debug for debugging code when failing rspec

.envrc
```sh
export RSPEC_DEBUG=1
```

`$ bundle exec rspec` 

```ruby

    8       it "has a version number" do
    9         expect(Appmatcher::VERSION).not_to be nil
   10       end
   11
+  12       # intentionally fail test for debugging
+  13       it "does something useful" do
+  14         expect(false).to eq(true)
+  15       end
+  16
   17       describe "#backend_klass" do
   18         subject { Appmatcher.backend_klass }
   19         context "when XDG_SESSION_TYPE is x11" do
   20           before { allow(Appmatcher).to receive(:xdg_session_type).and_return("x11") }
 NORMAL  plugin/appmatcher_spec.rb                                                                                                                                              unix | utf-8 | ruby  25%   14:9
    10|       end
    11|
    12|       # intentionally fail test for debugging
    13|       it "does something useful" do
=>  14|         expect(false).to eq(true)
    15|       end
    16|
    17|       describe "#backend_klass" do
    18|         subject { Appmatcher.backend_klass }
=>#0    block in <module:Plugin> (2 levels) at ~/.ghq/github.com/iberianpig/fusuma-plugin-appmatcher/spec/fusuma/plugin/appmatcher_spec.rb:14
  #1    [C] Kernel.load at ~/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.2.15/lib/bundler/cli/exec.rb:63
  # and 14 frames (use `bt' command for all frames)
(rdbg:postmortem)

```
