### PR TITLE
fix: xdg_current_desktop value for VS Code terminals

### DIFF
--- a/lib/fusuma/plugin/appmatcher.rb
+++ b/lib/fusuma/plugin/appmatcher.rb
@@ -42,7 +42,7 @@ module Fusuma
       end
 
       def xdg_current_desktop
-        ENV.fetch("XDG_CURRENT_DESKTOP", "")
+        ENV.fetch("ORIGINAL_XDG_CURRENT_DESKTOP", ENV.fetch("XDG_CURRENT_DESKTOP", ""))
       end
     end
   end


### PR DESCRIPTION
An [Electron/VS Code bug](https://github.com/electron/electron/issues/47414) causes `XDG_CURRENT_DESKTOP=Unity` when run from a VS Code terminal. This can be resolved by using `ORIGINAL_XDG_CURRENT_DESKTOP` when it is available.

Originally discussed in #16. 