### PR TITLE
Add layer switching integration with fusuma-plugin-remap

### DIFF
--- a/lib/fusuma/plugin/detectors/appmatcher_detector.rb
+++ b/lib/fusuma/plugin/detectors/appmatcher_detector.rb
@@ -23,12 +23,46 @@ module Fusuma
 
           record = buffer.events.last.record
 
+          update_layer(record.name) if layer_manager_available?
+
           context_record = Events::Records::ContextRecord.new(
             name: "application",
             value: record.name
           )
 
           create_event(record: context_record)
+        end
+
+        private
+
+        # Check fusuma-plugin-remap is installed for layer management
+        def layer_manager_available?
+          return @layer_manager_available if defined?(@layer_manager_available)
+
+          @layer_manager_available = Plugin::Manager.plugins[Inputs::Input.name]&.any? { |klass|
+            klass.name == "Fusuma::Plugin::Inputs::RemapKeyboardInput"
+          } || false
+        end
+
+        def layer_manager
+          require "fusuma/plugin/remap/layer_manager"
+          Fusuma::Plugin::Remap::LayerManager.instance
+        end
+
+        # Update layer on application change
+        # - On first detection: add current app as layer
+        # - On app change: remove previous layer and add new layer
+        # - On same app: do nothing
+        def update_layer(current_app)
+          return if @previous_app == current_app
+
+          if @previous_app
+            layer_manager.send_layer(layer: {application: @previous_app}, remove: true)
+          end
+
+          layer_manager.send_layer(layer: {application: current_app})
+
+          @previous_app = current_app
         end
       end
     end

--- a/spec/fusuma/plugin/detectors/appmatcher_detector_spec.rb
+++ b/spec/fusuma/plugin/detectors/appmatcher_detector_spec.rb
@@ -62,6 +62,125 @@ module Fusuma
             expect(record.value).to eq "dummy2"
           end
         end
+
+        describe "#layer_manager_available?" do
+          before do
+            # Reset cache before each test
+            if @detector.instance_variable_defined?(:@layer_manager_available)
+              @detector.remove_instance_variable(:@layer_manager_available)
+            end
+          end
+
+          context "when fusuma-plugin-remap is installed" do
+            before do
+              remap_input_class = double("RemapKeyboardInput", name: "Fusuma::Plugin::Inputs::RemapKeyboardInput")
+
+              allow(Plugin::Manager).to receive(:plugins).and_return({
+                Inputs::Input.name => [remap_input_class]
+              })
+            end
+
+            it "returns true" do
+              expect(@detector.send(:layer_manager_available?)).to be true
+            end
+          end
+
+          context "when fusuma-plugin-remap is NOT installed" do
+            before do
+              allow(Plugin::Manager).to receive(:plugins).and_return({
+                Inputs::Input.name => []
+              })
+            end
+
+            it "returns false" do
+              expect(@detector.send(:layer_manager_available?)).to be false
+            end
+          end
+
+          # Verify that the result is cached
+          context "called multiple times" do
+            it "returns cached result" do
+              allow(Plugin::Manager).to receive(:plugins).and_return({Inputs::Input.name => []})
+
+              result1 = @detector.send(:layer_manager_available?)
+              result2 = @detector.send(:layer_manager_available?)
+
+              expect(result1).to eq result2
+              expect(Plugin::Manager).to have_received(:plugins).once
+            end
+          end
+        end
+
+        describe "#update_layer" do
+          let(:layer_manager) { double("LayerManager") }
+
+          before do
+            if @detector.instance_variable_defined?(:@layer_manager_available)
+              @detector.remove_instance_variable(:@layer_manager_available)
+            end
+            if @detector.instance_variable_defined?(:@previous_app)
+              @detector.remove_instance_variable(:@previous_app)
+            end
+
+            allow(@detector).to receive(:layer_manager).and_return(layer_manager)
+            allow(layer_manager).to receive(:send_layer)
+          end
+
+          context "when detecting the app for the first time" do
+            it "adds current app layer" do
+              @detector.send(:update_layer, "google-chrome")
+
+              expect(layer_manager).to have_received(:send_layer).with(
+                layer: {application: "google-chrome"}
+              )
+            end
+
+            it "does not attempt to remove previous app layer" do
+              @detector.send(:update_layer, "google-chrome")
+
+              expect(layer_manager).not_to have_received(:send_layer).with(
+                hash_including(remove: true)
+              )
+            end
+          end
+
+          context "when changing to a different app" do
+            before do
+              @detector.send(:update_layer, "google-chrome")
+              allow(layer_manager).to receive(:send_layer)
+            end
+
+            it "deletes the previous app's layer" do
+              @detector.send(:update_layer, "code")
+
+              expect(layer_manager).to have_received(:send_layer).with(
+                layer: {application: "google-chrome"},
+                remove: true
+              )
+            end
+
+            it "adds the current app's layer" do
+              @detector.send(:update_layer, "code")
+
+              expect(layer_manager).to have_received(:send_layer).with(
+                layer: {application: "code"}
+              )
+            end
+          end
+
+          # Case of the same app: do nothing (to prevent duplicate sending)
+          context "with the same app as before" do
+            before do
+              @detector.instance_variable_set(:@previous_app, "google-chrome")
+            end
+
+            it "does not remove previous app layer" do
+              @detector.send(:update_layer, "google-chrome")
+
+              expect(layer_manager).not_to have_received(:send_layer)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- Integrate with LayerManager from fusuma-plugin-remap to dynamically switch keyboard remap layers when the active application changes
- Send layer context `{application: "app_name"}` on app change
- Remove previous app layer before adding new layer
- Skip duplicate sends when same app is detected
- Optional dependency: works without fusuma-plugin-remap installed

## Usage

This enables app-specific keyboard remapping in config.yml:

```yaml
---
context:
  application: Google-chrome

remap:
  LEFTCTRL+O: LEFTALT+LEFT
  LEFTCTRL+I: LEFTALT+RIGHT
  LEFTCTRL+B: LEFT
  LEFTCTRL+F: RIGHT
```

## Test plan
- [x] Unit tests pass (`bundle exec rspec`)
- [x] Manual test with fusuma-plugin-remap installed
- [x] Manual test without fusuma-plugin-remap (should work without errors)

🤖 Generated with [Claude Code](https://claude.ai/code)