### PR TITLE
Add Hyprland Wayland Compositor support

### DIFF
--- a/lib/fusuma/plugin/appmatcher.rb
+++ b/lib/fusuma/plugin/appmatcher.rb
@@ -5,6 +5,7 @@ require "fusuma/plugin/appmatcher/version"
 require "fusuma/plugin/appmatcher/x11"
 require "fusuma/plugin/appmatcher/gnome_extension"
 require "fusuma/plugin/appmatcher/gnome_extensions/installer"
+require "fusuma/plugin/appmatcher/hyprland"
 require "fusuma/plugin/appmatcher/unsupported_backend"
 
 module Fusuma
@@ -30,6 +31,8 @@ module Fusuma
               MultiLogger.warn "$ fusuma-appmatcher --install-gnome-extension"
               MultiLogger.warn ""
             end
+          when /Hyprland/i
+            return Hyprland if hyprland_available?
           end
         end
 
@@ -43,6 +46,17 @@ module Fusuma
 
       def xdg_current_desktop
         ENV.fetch("ORIGINAL_XDG_CURRENT_DESKTOP", ENV.fetch("XDG_CURRENT_DESKTOP", ""))
+      end
+
+      def hyprland_available?
+        instance_sig = ENV["HYPRLAND_INSTANCE_SIGNATURE"]
+        return false unless instance_sig
+
+        xdg_runtime = ENV.fetch("XDG_RUNTIME_DIR", "/tmp")
+        [
+          File.join(xdg_runtime, "hypr", instance_sig, ".socket2.sock"),
+          File.join("/tmp", "hypr", instance_sig, ".socket2.sock")
+        ].any? { |p| File.exist?(p) }
       end
     end
   end

--- a/lib/fusuma/plugin/appmatcher/hyprland.rb
+++ b/lib/fusuma/plugin/appmatcher/hyprland.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "socket"
+require "json"
+require_relative "user_switcher"
+require "fusuma/multi_logger"
+require "fusuma/custom_process"
+
+module Fusuma
+  module Plugin
+    module Appmatcher
+      # Search Active Window's Name for Hyprland
+      class Hyprland
+        include UserSwitcher
+
+        attr_reader :reader, :writer
+
+        def initialize
+          @reader, @writer = IO.pipe
+        end
+
+        # fork process and watch signal
+        # @return [Integer] Process id
+        def watch_start
+          as_user(proctitle: self.class.name.underscore) do |_user|
+            @reader.close
+            register_on_application_changed(Matcher.new)
+          end
+        end
+
+        private
+
+        def register_on_application_changed(matcher)
+          @writer.puts(matcher.active_application || "NOT FOUND")
+
+          matcher.on_active_application_changed do |name|
+            notify(name)
+          end
+        end
+
+        def notify(name)
+          @writer.puts(name)
+        rescue Errno::EPIPE
+          exit 0
+        rescue => e
+          MultiLogger.error e.message
+          exit 1
+        end
+
+        # Look up application name using hyprctl
+        class Matcher
+          ACTIVEWINDOW_EVENT = "activewindow"
+
+          # @return [Array<String>]
+          def running_applications
+            output = `hyprctl clients -j 2>/dev/null`
+            return [] if output.empty?
+            JSON.parse(output).map { |c| c["class"] }.compact.uniq
+          rescue JSON::ParserError
+            []
+          end
+
+          # @return [String, nil]
+          def active_application
+            output = `hyprctl -j activewindow 2>/dev/null`
+            return nil if output.empty? || output.strip == "{}"
+            JSON.parse(output)["class"]
+          rescue JSON::ParserError
+            nil
+          end
+
+          def on_active_application_changed
+            socket = connect_to_socket2
+            return unless socket
+
+            loop do
+              line = socket.gets
+              break unless line
+
+              event, data = line.chomp.split(">>", 2)
+              next unless event == ACTIVEWINDOW_EVENT
+
+              window_class, _window_title = data.split(",", 2)
+              yield(window_class.to_s.empty? ? "NOT FOUND" : window_class)
+            end
+          rescue Errno::ECONNRESET, Errno::EPIPE, IOError
+            # socket disconnected
+          ensure
+            socket&.close
+          end
+
+          private
+
+          # @return [String, nil]
+          def find_socket_path
+            instance_sig = ENV["HYPRLAND_INSTANCE_SIGNATURE"]
+            return nil unless instance_sig
+
+            xdg_runtime = ENV.fetch("XDG_RUNTIME_DIR", "/tmp")
+            [
+              File.join(xdg_runtime, "hypr", instance_sig, ".socket2.sock"),
+              File.join("/tmp", "hypr", instance_sig, ".socket2.sock")
+            ].find { |p| File.exist?(p) }
+          end
+
+          # @return [UNIXSocket, nil]
+          def connect_to_socket2
+            path = find_socket_path
+            return nil unless path
+            UNIXSocket.new(path)
+          rescue Errno::ENOENT, Errno::ECONNREFUSED
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fusuma/plugin/appmatcher/hyprland_spec.rb
+++ b/spec/fusuma/plugin/appmatcher/hyprland_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fusuma/plugin/appmatcher/hyprland"
+
+module Fusuma
+  module Plugin
+    module Appmatcher
+      RSpec.describe Hyprland do
+        let(:hyprland) { Hyprland.new }
+
+        describe "#initialize" do
+          it "creates IO pipe for reader" do
+            expect(hyprland.reader).to be_a(IO)
+          end
+
+          it "creates IO pipe for writer" do
+            expect(hyprland.writer).to be_a(IO)
+          end
+        end
+
+        describe Hyprland::Matcher do
+          let(:matcher) { Hyprland::Matcher.new }
+
+          before do
+            allow(ENV).to receive(:[]).and_call_original
+            allow(ENV).to receive(:fetch).and_call_original
+          end
+
+          describe "#active_application" do
+            context "when hyprctl returns valid JSON" do
+              before do
+                allow(matcher).to receive(:`).with("hyprctl -j activewindow 2>/dev/null")
+                  .and_return('{"class":"kitty","title":"terminal"}')
+              end
+
+              it "returns the window class" do
+                expect(matcher.active_application).to eq("kitty")
+              end
+            end
+
+            context "when hyprctl returns empty string" do
+              before do
+                allow(matcher).to receive(:`).with("hyprctl -j activewindow 2>/dev/null")
+                  .and_return("")
+              end
+
+              it "returns nil" do
+                expect(matcher.active_application).to be_nil
+              end
+            end
+
+            context "when hyprctl returns empty object" do
+              before do
+                allow(matcher).to receive(:`).with("hyprctl -j activewindow 2>/dev/null")
+                  .and_return("{}")
+              end
+
+              it "returns nil" do
+                expect(matcher.active_application).to be_nil
+              end
+            end
+
+            context "when hyprctl returns invalid JSON" do
+              before do
+                allow(matcher).to receive(:`).with("hyprctl -j activewindow 2>/dev/null")
+                  .and_return("not json")
+              end
+
+              it "returns nil" do
+                expect(matcher.active_application).to be_nil
+              end
+            end
+          end
+
+          describe "#running_applications" do
+            context "when hyprctl returns valid clients" do
+              before do
+                allow(matcher).to receive(:`).with("hyprctl clients -j 2>/dev/null")
+                  .and_return('[{"class":"kitty"},{"class":"firefox"},{"class":"kitty"}]')
+              end
+
+              it "returns unique window classes" do
+                expect(matcher.running_applications).to contain_exactly("kitty", "firefox")
+              end
+            end
+
+            context "when hyprctl returns empty array" do
+              before do
+                allow(matcher).to receive(:`).with("hyprctl clients -j 2>/dev/null")
+                  .and_return("[]")
+              end
+
+              it "returns empty array" do
+                expect(matcher.running_applications).to eq([])
+              end
+            end
+
+            context "when hyprctl returns empty string" do
+              before do
+                allow(matcher).to receive(:`).with("hyprctl clients -j 2>/dev/null")
+                  .and_return("")
+              end
+
+              it "returns empty array" do
+                expect(matcher.running_applications).to eq([])
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add Hyprland backend for detecting active window on Hyprland Wayland Compositor
- Automatically detect Hyprland environment via `XDG_CURRENT_DESKTOP` and socket availability
- Monitor `activewindow` events via IPC socket (`.socket2.sock`)
- Use `hyprctl` command for getting current window class and running applications

## Implementation

- New file: `lib/fusuma/plugin/appmatcher/hyprland.rb`
- Modified: `lib/fusuma/plugin/appmatcher.rb` (environment detection)
- New test: `spec/fusuma/plugin/appmatcher/hyprland_spec.rb`
- Modified test: `spec/fusuma/plugin/appmatcher_spec.rb`

## Hyprland IPC

- Socket path: `${XDG_RUNTIME_DIR}/hypr/${HYPRLAND_INSTANCE_SIGNATURE}/.socket2.sock`
- Event format: `activewindow>>class,title\n`

## Test plan

- [x] Run `bundle exec rspec` - all tests pass
- [x] Test on actual Hyprland environment with `fusuma-appmatcher -l`
```bash
fusuma-plugin-appmatcher HEAD ❯ bundle exec fusuma-appmatcher -l                                                                                                                                                                               
com.mitchellh.ghostty                                                                                                                                                                                                                          
org.gnome.Nautilus 

```
- [x] Verify window class detection when switching windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)