### PR TITLE
Add Sway backend for wlroots-based compositor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Fusuma](https://github.com/iberianpig/fusuma) plugin configure app-specific gestures
 
 * Switch gesture mappings by detecting active application.
-* Support X11, GNOME Wayland, Hyprland
+* Support X11, GNOME Wayland, Hyprland, Sway
 
 
 ## Installation
@@ -156,7 +156,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/iberia
 
 ### Help Wanted: Support for Other Wayland Compositors
 
-Currently, this plugin supports X11, GNOME Wayland, and Hyprland. We'd love to expand support to other Wayland compositors (Sway, KDE Plasma, wlroots-based compositors, etc.).
+Currently, this plugin supports X11, GNOME Wayland, Hyprland, and Sway. We'd love to expand support to other Wayland compositors (KDE Plasma, other wlroots-based compositors, etc.).
 
 If you're using an unsupported compositor:
 - Please [open an issue](https://github.com/iberianpig/fusuma-plugin-appmatcher/issues) to let us know

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Fusuma](https://github.com/iberianpig/fusuma) plugin configure app-specific gestures
 
 * Switch gesture mappings by detecting active application.
-* Support X11, GNOME Wayland, Hyprland, COSMIC
+* Support X11, GNOME Wayland, Hyprland, COSMIC, Sway
 
 
 ## Installation
@@ -164,7 +164,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/iberia
 
 ### Help Wanted: Support for Other Wayland Compositors
 
-Currently, this plugin supports X11, GNOME Wayland, Hyprland, and COSMIC. We'd love to expand support to other Wayland compositors (Sway, KDE Plasma, wlroots-based compositors, etc.).
+Currently, this plugin supports X11, GNOME Wayland, Hyprland, COSMIC, and Sway. We'd love to expand support to other Wayland compositors (KDE Plasma, other wlroots-based compositors, etc.).
 
 If you're using an unsupported compositor:
 - Please [open an issue](https://github.com/iberianpig/fusuma-plugin-appmatcher/issues) to let us know

--- a/lib/fusuma/plugin/appmatcher.rb
+++ b/lib/fusuma/plugin/appmatcher.rb
@@ -6,6 +6,7 @@ require "fusuma/plugin/appmatcher/x11"
 require "fusuma/plugin/appmatcher/gnome_extension"
 require "fusuma/plugin/appmatcher/gnome_extensions/installer"
 require "fusuma/plugin/appmatcher/hyprland"
+require "fusuma/plugin/appmatcher/sway"
 require "fusuma/plugin/appmatcher/unsupported_backend"
 
 module Fusuma
@@ -33,6 +34,13 @@ module Fusuma
             end
           when /Hyprland/i
             return Hyprland if hyprland_available?
+          when /sway/i
+            if Sway.available?
+              return Sway
+            else
+              MultiLogger.warn "swaymsg command not found"
+              MultiLogger.warn "Please install sway to use appmatcher with Sway"
+            end
           end
         end
 

--- a/lib/fusuma/plugin/appmatcher.rb
+++ b/lib/fusuma/plugin/appmatcher.rb
@@ -7,6 +7,7 @@ require "fusuma/plugin/appmatcher/gnome_extension"
 require "fusuma/plugin/appmatcher/gnome_extensions/installer"
 require "fusuma/plugin/appmatcher/hyprland"
 require "fusuma/plugin/appmatcher/cosmic"
+require "fusuma/plugin/appmatcher/sway"
 require "fusuma/plugin/appmatcher/unsupported_backend"
 
 module Fusuma
@@ -43,6 +44,13 @@ module Fusuma
               MultiLogger.warn ""
               MultiLogger.warn "  $ cargo install --git https://github.com/estin/cos-cli"
               MultiLogger.warn ""
+            end
+          when /sway/i
+            if Sway.available?
+              return Sway
+            else
+              MultiLogger.warn "swaymsg command not found"
+              MultiLogger.warn "Please install sway to use appmatcher with Sway"
             end
           end
         end

--- a/lib/fusuma/plugin/appmatcher/sway.rb
+++ b/lib/fusuma/plugin/appmatcher/sway.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "open3"
+require "json"
+require_relative "user_switcher"
+require "fusuma/multi_logger"
+require "fusuma/custom_process"
+
+module Fusuma
+  module Plugin
+    module Appmatcher
+      # Search Active Window's Name for Sway (wlroots-based compositor)
+      class Sway
+        include UserSwitcher
+
+        attr_reader :reader, :writer
+
+        # Check if swaymsg command is available
+        # @return [Boolean]
+        def self.available?
+          system("which swaymsg > /dev/null 2>&1")
+        end
+
+        def initialize
+          @reader, @writer = IO.pipe
+        end
+
+        # fork process and watch signal
+        # @return [Integer] Process id
+        def watch_start
+          as_user(proctitle: self.class.name.underscore) do |_user|
+            @reader.close
+            register_on_application_changed(Matcher.new)
+          end
+        end
+
+        private
+
+        def register_on_application_changed(matcher)
+          matcher.on_active_application_changed do |name|
+            notify(name)
+          end
+        end
+
+        def notify(name)
+          @writer.puts(name)
+        rescue Errno::EPIPE
+          exit 0
+        rescue => e
+          MultiLogger.error e.message
+          exit 1
+        end
+
+        # Look up application name using swaymsg
+        class Matcher
+          def initialize
+            @cache = {}
+          end
+
+          # @return [Array<String>]
+          def running_applications
+            tree = fetch_tree
+            collect_app_names(tree).compact.uniq
+          rescue => e
+            MultiLogger.error "Failed to get running applications: #{e.message}"
+            []
+          end
+
+          # @return [String]
+          # @return [NilClass]
+          def active_application
+            tree = fetch_tree
+            focused = find_focused_node(tree)
+            extract_app_name(focused)
+          rescue => e
+            MultiLogger.error "Failed to get active application: #{e.message}"
+            nil
+          end
+
+          # Subscribe to window focus events and yield application name on change
+          def on_active_application_changed
+            subscribe_window_events do |event|
+              next unless event["change"] == "focus"
+
+              container = event["container"]
+              app_name = extract_app_name(container)
+              yield(app_name || "NOT FOUND") if app_name || container
+            end
+          rescue => e
+            MultiLogger.error "Sway subscription error: #{e.message}"
+            sleep 1
+            retry
+          end
+
+          private
+
+          # Fetch the current window tree from sway
+          # @return [Hash]
+          def fetch_tree
+            output = `swaymsg -t get_tree`
+            JSON.parse(output)
+          end
+
+          # Subscribe to sway window events
+          def subscribe_window_events
+            cmd = ["swaymsg", "-m", "-t", "subscribe", '["window"]']
+            Open3.popen3(*cmd) do |stdin, stdout, stderr, wait_thr|
+              stdin.close
+              stdout.each_line do |line|
+                event = JSON.parse(line)
+                yield event
+              rescue JSON::ParserError => e
+                MultiLogger.warn "Failed to parse sway event: #{e.message}"
+              end
+              MultiLogger.error stderr.read if stdout.eof?
+            end
+          rescue Errno::ENOENT
+            MultiLogger.error "swaymsg command not found. Is sway installed?"
+            raise
+          end
+
+          # Recursively find the focused node in the tree
+          # @param node [Hash]
+          # @return [Hash, nil]
+          def find_focused_node(node)
+            return node if node["focused"]
+
+            # Check regular nodes
+            (node["nodes"] || []).each do |child|
+              result = find_focused_node(child)
+              return result if result
+            end
+
+            # Check floating nodes
+            (node["floating_nodes"] || []).each do |child|
+              result = find_focused_node(child)
+              return result if result
+            end
+
+            nil
+          end
+
+          # Extract application name from container
+          # Wayland native apps use app_id, XWayland apps use window_properties.class
+          # @param container [Hash, nil]
+          # @return [String, nil]
+          def extract_app_name(container)
+            return nil unless container
+
+            # Wayland native application
+            app_id = container["app_id"]
+            return app_id if app_id && !app_id.empty?
+
+            # XWayland application (fallback)
+            window_props = container["window_properties"]
+            window_props&.dig("class")
+          end
+
+          # Recursively collect all application names from the tree
+          # @param node [Hash]
+          # @param apps [Array<String>]
+          # @return [Array<String>]
+          def collect_app_names(node, apps = [])
+            app_name = extract_app_name(node)
+            apps << app_name if app_name
+
+            (node["nodes"] || []).each { |child| collect_app_names(child, apps) }
+            (node["floating_nodes"] || []).each { |child| collect_app_names(child, apps) }
+
+            apps
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fusuma/plugin/appmatcher/sway.rb
+++ b/lib/fusuma/plugin/appmatcher/sway.rb
@@ -37,6 +37,8 @@ module Fusuma
         private
 
         def register_on_application_changed(matcher)
+          @writer.puts(matcher.active_application || "NOT FOUND")
+
           matcher.on_active_application_changed do |name|
             notify(name)
           end

--- a/lib/fusuma/plugin/appmatcher/sway.rb
+++ b/lib/fusuma/plugin/appmatcher/sway.rb
@@ -15,10 +15,14 @@ module Fusuma
 
         attr_reader :reader, :writer
 
-        # Check if swaymsg command is available
+        # Search PATH in pure Ruby: the external `which` command is not
+        # installed on minimal systems (e.g. Arch containers).
         # @return [Boolean]
         def self.available?
-          system("which swaymsg > /dev/null 2>&1")
+          ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).any? do |dir|
+            path = File.join(dir, "swaymsg")
+            File.executable?(path) && !File.directory?(path)
+          end
         end
 
         def initialize
@@ -106,7 +110,7 @@ module Fusuma
           # Subscribe to sway window events
           def subscribe_window_events
             cmd = ["swaymsg", "-m", "-t", "subscribe", '["window"]']
-            Open3.popen3(*cmd) do |stdin, stdout, stderr, wait_thr|
+            Open3.popen3(*cmd) do |stdin, stdout, stderr, _wait_thr|
               stdin.close
               stdout.each_line do |line|
                 event = JSON.parse(line)
@@ -114,7 +118,9 @@ module Fusuma
               rescue JSON::ParserError => e
                 MultiLogger.warn "Failed to parse sway event: #{e.message}"
               end
-              MultiLogger.error stderr.read if stdout.eof?
+              # A clean swaymsg exit must not stop the watcher silently:
+              # raise so on_active_application_changed resubscribes via retry.
+              raise "swaymsg subscribe exited: #{stderr.read}"
             end
           rescue Errno::ENOENT
             MultiLogger.error "swaymsg command not found. Is sway installed?"

--- a/spec/fusuma/plugin/appmatcher/sway_spec.rb
+++ b/spec/fusuma/plugin/appmatcher/sway_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Fusuma
+  module Plugin
+    module Appmatcher
+      RSpec.describe Sway do
+        describe ".available?" do
+          subject { described_class.available? }
+
+          context "when swaymsg command exists" do
+            before do
+              allow(described_class).to receive(:system).with("which swaymsg > /dev/null 2>&1").and_return(true)
+            end
+            it { is_expected.to be true }
+          end
+
+          context "when swaymsg command does not exist" do
+            before do
+              allow(described_class).to receive(:system).with("which swaymsg > /dev/null 2>&1").and_return(false)
+            end
+            it { is_expected.to be false }
+          end
+        end
+
+        describe "#initialize" do
+          it "creates an IO pipe" do
+            sway = described_class.new
+            expect(sway.reader).to be_a(IO)
+            expect(sway.writer).to be_a(IO)
+            sway.reader.close
+            sway.writer.close
+          end
+        end
+
+        describe Sway::Matcher do
+          let(:matcher) { described_class.new }
+
+          describe "#extract_app_name" do
+            subject { matcher.send(:extract_app_name, container) }
+
+            context "when container is nil" do
+              let(:container) { nil }
+              it { is_expected.to be_nil }
+            end
+
+            context "when container has app_id (Wayland native)" do
+              let(:container) { {"app_id" => "firefox", "name" => "Mozilla Firefox"} }
+              it { is_expected.to eq "firefox" }
+            end
+
+            context "when container has empty app_id but has window_properties (XWayland)" do
+              let(:container) do
+                {
+                  "app_id" => nil,
+                  "window_properties" => {"class" => "Google-chrome"}
+                }
+              end
+              it { is_expected.to eq "Google-chrome" }
+            end
+
+            context "when container has empty string app_id" do
+              let(:container) do
+                {
+                  "app_id" => "",
+                  "window_properties" => {"class" => "Slack"}
+                }
+              end
+              it { is_expected.to eq "Slack" }
+            end
+
+            context "when container has both app_id and window_properties" do
+              let(:container) do
+                {
+                  "app_id" => "alacritty",
+                  "window_properties" => {"class" => "SomeClass"}
+                }
+              end
+              it "prefers app_id" do
+                is_expected.to eq "alacritty"
+              end
+            end
+          end
+
+          describe "#find_focused_node" do
+            subject { matcher.send(:find_focused_node, tree) }
+
+            context "when root node is focused" do
+              let(:tree) { {"focused" => true, "app_id" => "root"} }
+              it { is_expected.to eq tree }
+            end
+
+            context "when a child node is focused" do
+              let(:tree) do
+                {
+                  "focused" => false,
+                  "nodes" => [
+                    {"focused" => false, "app_id" => "unfocused"},
+                    {"focused" => true, "app_id" => "focused_app"}
+                  ]
+                }
+              end
+              it { is_expected.to eq({"focused" => true, "app_id" => "focused_app"}) }
+            end
+
+            context "when a floating node is focused" do
+              let(:tree) do
+                {
+                  "focused" => false,
+                  "nodes" => [],
+                  "floating_nodes" => [
+                    {"focused" => true, "app_id" => "floating_app"}
+                  ]
+                }
+              end
+              it { is_expected.to eq({"focused" => true, "app_id" => "floating_app"}) }
+            end
+
+            context "when deeply nested node is focused" do
+              let(:tree) do
+                {
+                  "focused" => false,
+                  "nodes" => [
+                    {
+                      "focused" => false,
+                      "nodes" => [
+                        {"focused" => true, "app_id" => "deep_app"}
+                      ]
+                    }
+                  ]
+                }
+              end
+              it { is_expected.to eq({"focused" => true, "app_id" => "deep_app"}) }
+            end
+
+            context "when no node is focused" do
+              let(:tree) do
+                {
+                  "focused" => false,
+                  "nodes" => [
+                    {"focused" => false, "app_id" => "app1"}
+                  ]
+                }
+              end
+              it { is_expected.to be_nil }
+            end
+          end
+
+          describe "#collect_app_names" do
+            subject { matcher.send(:collect_app_names, tree) }
+
+            let(:tree) do
+              {
+                "app_id" => nil,
+                "nodes" => [
+                  {"app_id" => "firefox"},
+                  {"app_id" => "alacritty"},
+                  {
+                    "app_id" => nil,
+                    "nodes" => [
+                      {"app_id" => "code"}
+                    ]
+                  }
+                ],
+                "floating_nodes" => [
+                  {"app_id" => nil, "window_properties" => {"class" => "Slack"}}
+                ]
+              }
+            end
+
+            it "collects all app names from the tree" do
+              expect(subject).to contain_exactly("firefox", "alacritty", "code", "Slack")
+            end
+          end
+
+          describe "#running_applications" do
+            subject { matcher.running_applications }
+
+            let(:tree_json) do
+              {
+                "nodes" => [
+                  {"app_id" => "firefox"},
+                  {"app_id" => "alacritty"},
+                  {"app_id" => "firefox"} # duplicate
+                ]
+              }.to_json
+            end
+
+            before do
+              allow(matcher).to receive(:`).with("swaymsg -t get_tree").and_return(tree_json)
+            end
+
+            it "returns unique app names" do
+              expect(subject).to contain_exactly("firefox", "alacritty")
+            end
+          end
+
+          describe "#active_application" do
+            subject { matcher.active_application }
+
+            let(:tree_json) do
+              {
+                "focused" => false,
+                "nodes" => [
+                  {"focused" => true, "app_id" => "active_app"}
+                ]
+              }.to_json
+            end
+
+            before do
+              allow(matcher).to receive(:`).with("swaymsg -t get_tree").and_return(tree_json)
+            end
+
+            it "returns the focused app name" do
+              expect(subject).to eq "active_app"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fusuma/plugin/appmatcher/sway_spec.rb
+++ b/spec/fusuma/plugin/appmatcher/sway_spec.rb
@@ -1,26 +1,50 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tmpdir"
 
 module Fusuma
   module Plugin
     module Appmatcher
       RSpec.describe Sway do
         describe ".available?" do
-          subject { described_class.available? }
+          # available? searches PATH in pure Ruby (no external `which`,
+          # which is not installed on minimal systems like Arch containers).
+          context "when swaymsg is found in PATH" do
+            it "returns true" do
+              Dir.mktmpdir do |dir|
+                exe = File.join(dir, "swaymsg")
+                File.write(exe, "")
+                File.chmod(0o755, exe)
+                allow(ENV).to receive(:fetch).and_call_original
+                allow(ENV).to receive(:fetch).with("PATH", "").and_return(dir)
 
-          context "when swaymsg command exists" do
-            before do
-              allow(described_class).to receive(:system).with("which swaymsg > /dev/null 2>&1").and_return(true)
+                expect(described_class.available?).to be true
+              end
             end
-            it { is_expected.to be true }
           end
 
-          context "when swaymsg command does not exist" do
-            before do
-              allow(described_class).to receive(:system).with("which swaymsg > /dev/null 2>&1").and_return(false)
+          context "when swaymsg is not in PATH" do
+            it "returns false" do
+              Dir.mktmpdir do |dir|
+                allow(ENV).to receive(:fetch).and_call_original
+                allow(ENV).to receive(:fetch).with("PATH", "").and_return(dir)
+
+                expect(described_class.available?).to be false
+              end
             end
-            it { is_expected.to be false }
+          end
+
+          context "when PATH entry contains a directory named swaymsg" do
+            it "returns false" do
+              Dir.mktmpdir do |dir|
+                Dir.mkdir(File.join(dir, "swaymsg"))
+                allow(ENV).to receive(:fetch).and_call_original
+                allow(ENV).to receive(:fetch).with("PATH", "").and_return(dir)
+
+                expect(described_class.available?).to be false
+              end
+            end
           end
         end
 
@@ -214,6 +238,85 @@ module Fusuma
 
             it "returns the focused app name" do
               expect(subject).to eq "active_app"
+            end
+          end
+
+          describe "#on_active_application_changed" do
+            # Build a sway window event line as emitted by
+            # `swaymsg -m -t subscribe '["window"]'`
+            def focus_event(app_id)
+              {
+                "change" => "focus",
+                "container" => {"app_id" => app_id}
+              }.to_json + "\n"
+            end
+
+            # Stub Open3.popen3 to feed the given lines as swaymsg stdout.
+            def stub_subscribe(lines)
+              stdout = StringIO.new(lines.join)
+              stderr = StringIO.new("")
+              stdin = StringIO.new
+              wait_thr = double("wait_thr")
+              allow(Open3).to receive(:popen3)
+                .with("swaymsg", "-m", "-t", "subscribe", '["window"]')
+                .and_yield(stdin, stdout, stderr, wait_thr)
+              stdin
+            end
+
+            # A clean swaymsg exit raises so on_active_application_changed
+            # resubscribes via its `rescue => e; sleep 1; retry` loop.
+            # The sleep stub raises SystemExit to break out of that infinite
+            # retry loop in tests (SystemExit is not a StandardError, so
+            # `rescue => e` does not catch it).
+            before do
+              allow(Fusuma::MultiLogger).to receive(:error)
+              allow(matcher).to receive(:sleep).and_raise(SystemExit)
+            end
+
+            # Runs the subscription until the stubbed stdout is exhausted
+            # (then the sleep stub raises SystemExit) and returns yielded names.
+            def watch_until_exit
+              yielded = []
+              expect {
+                matcher.on_active_application_changed { |name| yielded << name }
+              }.to raise_error(SystemExit)
+              yielded
+            end
+
+            it "yields app name on focus event" do
+              stub_subscribe([focus_event("firefox")])
+              expect(watch_until_exit).to eq(["firefox"])
+            end
+
+            it "ignores non-focus events" do
+              other = {"change" => "title", "container" => {"app_id" => "kitty"}}.to_json + "\n"
+              stub_subscribe([other, focus_event("alacritty")])
+              expect(watch_until_exit).to eq(["alacritty"])
+            end
+
+            it "skips invalid JSON lines" do
+              allow(Fusuma::MultiLogger).to receive(:warn)
+              stub_subscribe(["not json\n", focus_event("kitty")])
+              expect(watch_until_exit).to eq(["kitty"])
+              expect(Fusuma::MultiLogger).to have_received(:warn).with(/Failed to parse/)
+            end
+
+            it "retries when swaymsg exits cleanly" do
+              # A clean swaymsg exit (stdout EOF, no exception) must not stop
+              # the watcher silently; it raises and enters the retry loop.
+              stub_subscribe([])
+              watch_until_exit
+              expect(Fusuma::MultiLogger).to have_received(:error).with(/swaymsg .*exited/)
+            end
+
+            it "logs and retries when swaymsg is missing" do
+              allow(Open3).to receive(:popen3)
+                .with("swaymsg", "-m", "-t", "subscribe", '["window"]')
+                .and_raise(Errno::ENOENT)
+
+              watch_until_exit
+
+              expect(Fusuma::MultiLogger).to have_received(:error).with(/swaymsg command not found/)
             end
           end
         end

--- a/spec/fusuma/plugin/appmatcher_spec.rb
+++ b/spec/fusuma/plugin/appmatcher_spec.rb
@@ -37,6 +37,32 @@ module Fusuma
             end
           end
 
+          context "when XDG_CURRENT_DESKTOP is sway" do
+            before { allow(Appmatcher).to receive(:xdg_current_desktop).and_return("sway") }
+
+            context "when swaymsg is available" do
+              before do
+                allow(Appmatcher::Sway).to receive(:available?).and_return(true)
+              end
+              it { is_expected.to eq Appmatcher::Sway }
+            end
+
+            context "when swaymsg is NOT available" do
+              before do
+                allow(Appmatcher::Sway).to receive(:available?).and_return(false)
+              end
+              it { is_expected.to eq Appmatcher::UnsupportedBackend }
+            end
+          end
+
+          context "when XDG_CURRENT_DESKTOP is Sway (capitalized)" do
+            before do
+              allow(Appmatcher).to receive(:xdg_current_desktop).and_return("Sway")
+              allow(Appmatcher::Sway).to receive(:available?).and_return(true)
+            end
+            it { is_expected.to eq Appmatcher::Sway }
+          end
+
           context "when XDG_CURRENT_DESKTOP is UNKNOWN" do
             before do
               allow(Appmatcher).to receive(:xdg_current_desktop).and_return("UNKNOWN")


### PR DESCRIPTION
## Summary

- Add Sway (wlroots-based Wayland compositor) as a new backend for detecting focused applications
- Uses `swaymsg` IPC to subscribe to window focus events and extract `app_id` (Wayland native) or `window_properties.class` (XWayland)
- Follows the same architecture as existing backends (Hyprland, GNOME Extension, X11, COSMIC)

## Changes

- **`lib/fusuma/plugin/appmatcher/sway.rb`** - New `Sway` backend class with `Matcher` for IPC communication
- **`lib/fusuma/plugin/appmatcher.rb`** - Register Sway backend, detected via `XDG_CURRENT_DESKTOP=sway`
- **`spec/fusuma/plugin/appmatcher/sway_spec.rb`** - Full test coverage for the Sway backend
- **`spec/fusuma/plugin/appmatcher_spec.rb`** - Backend selection tests for Sway
- **`README.md`** - Updated supported compositor list

### Fixes applied from COSMIC backend review (#21)

- `available?` searches PATH in pure Ruby instead of shelling out to `which`, which is not installed on minimal systems (e.g. Arch containers) — verified in container: old implementation fell back to `UnsupportedBackend`
- A clean exit of `swaymsg -m -t subscribe` now raises so the watcher resubscribes via the retry loop instead of dying silently

## Test plan

- [x] All unit tests pass (88 examples, 0 failures)
- [x] E2E verified on headless Sway in Docker (Arch, `WLR_BACKENDS=headless` + pixman):
  - [x] Backend selection via `XDG_CURRENT_DESKTOP=sway` returns `Sway`
  - [x] Initial focused app is notified on watcher start
  - [x] Wayland native apps return `app_id` (`foot`, `foot --app-id=editor`)
  - [x] XWayland apps fall back to `window_properties.class` (`xterm` → `XTerm`)
  - [x] Killing the `swaymsg -m` subscribe process triggers resubscribe (focus events keep flowing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)